### PR TITLE
turn off sam's sonar 

### DIFF
--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "com.smarc.assets",
+  "version": "0.0.1",
+  "displayName": "SMARC Unity Assets",
+  "description": "Contains the assorted models, scripts and utils used by all SMARC Unity projects.",
+  "documentationUrl": "https://github.com/martkartasev/SMARC_Unity",
+  "changelogUrl": "https://github.com/martkartasev/SMARC_Unity",
+  "licensesUrl": "https://github.com/martkartasev/SMARC_Unity",
+  "author": {
+    "name": "Mart Kartasev",
+    "email": "mart.kartasev@gmail.com",
+    "url": "https://www.linkedin.com/in/mart-karta%C5%A1ev-a67410114/"
+  }
+}

--- a/Assets/package.json.meta
+++ b/Assets/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d74ecee97c9ef6c09a181b21264cd397
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
disable the sam_auv_v1/sidescan_link in unity to turn off the sonar 
for airborne recovery scene.

Thus, quadrotor's camera can detect the sam_auv